### PR TITLE
Adding ELI5 and Rust Nibbles to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ Gazebo can be depended upon by adding `gazebo` to your `[dependencies]`, using t
 
 The two interesting directories in this repo are `gazebo` (which contains the source to Gazebo itself) and `gazebo_derive` (which contains support for `#[derive(Dupe)]` and other Gazebo traits). Usually you will directly import `gazebo`, but `gazebo_derive` is a required transitive dependency if you are sourcing the library from GitHub.
 
+## Learn More 
+
+Watch this introductory video abotu Gazebo from [Meta Open Source Team](https://opensource.facebook.com/):
+
+[![Explain Like I’m 5: Gazebo](https://img.youtube.com/vi/pQJkx9HL_04/0.jpg)](https://www.youtube.com/watch?v=OsrBYHIYCYk)
+
+You can also read about Gazebo functionalities in detail in our series of blog posts called [Rust Nibbles](https://developers.facebook.com/blog/?q=Rust+Nibbles):
+
+* [Rust Nibbles - Gazebo : Dupe](https://developers.facebook.com/blog/post/2021/07/06/rust-nibbles-gazebo-dupe/)
+* [Rust Nibbles - Gazebo: Comparisons](https://developers.facebook.com/blog/post/2021/07/27/rust-nibbles-gazebo-comparisons/)
+* [Rust Nibbles - Gazebo: Casts and Transmute](https://developers.facebook.com/blog/post/2021/08/03/rust-nibbles-gazebo-casts-transmute/)
+* [Rust Nibbles - Gazebo: The rest of the tent](https://developers.facebook.com/blog/post/2021/08/10/rust-nibbles-gazebo-rest-of-tent/)
+* [Rust Nibbles - Gazebo: Prelude](https://developers.facebook.com/blog/post/2021/06/29/rust-nibbles-gazebo-prelude/)
+* [Rust Nibbles - Gazebo: AnyLifetime](https://developers.facebook.com/blog/post/2021/07/20/rust-nibbles-gazebo-any-lifetime/)
+* [Rust Nibbles - Gazebo: Variants](https://developers.facebook.com/blog/post/2021/07/13/rust-nibbles-gazebo-variants)
+
 ## Making a release
 
 1. Check the [GitHub Actions](https://github.com/facebookincubator/gazebo/actions) are green.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ The two interesting directories in this repo are `gazebo` (which contains the so
 
 ## Learn More 
 
-Watch this introductory video about Gazebo from [Meta Open Source Team](https://opensource.facebook.com/):
 
-[![Explain Like I’m 5: Gazebo](https://img.youtube.com/vi/pQJkx9HL_04/0.jpg)](https://www.youtube.com/watch?v=OsrBYHIYCYk)
+You can learn more about Gazebo in [this introductory video](https://www.youtube.com/watch?v=OsrBYHIYCYk) from [Meta Open Source team](https://opensource.facebook.com/).
 
 You can also read about Gazebo functionalities in detail in our series of blog posts called [Rust Nibbles](https://developers.facebook.com/blog/?q=Rust+Nibbles):
 
-* [Rust Nibbles - Gazebo : Dupe](https://developers.facebook.com/blog/post/2021/07/06/rust-nibbles-gazebo-dupe/)
+* [Rust Nibbles - Gazebo: Dupe](https://developers.facebook.com/blog/post/2021/07/06/rust-nibbles-gazebo-dupe/)
 * [Rust Nibbles - Gazebo: Comparisons](https://developers.facebook.com/blog/post/2021/07/27/rust-nibbles-gazebo-comparisons/)
 * [Rust Nibbles - Gazebo: Casts and Transmute](https://developers.facebook.com/blog/post/2021/08/03/rust-nibbles-gazebo-casts-transmute/)
 * [Rust Nibbles - Gazebo: The rest of the tent](https://developers.facebook.com/blog/post/2021/08/10/rust-nibbles-gazebo-rest-of-tent/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The two interesting directories in this repo are `gazebo` (which contains the so
 
 ## Learn More 
 
-Watch this introductory video abotu Gazebo from [Meta Open Source Team](https://opensource.facebook.com/):
+Watch this introductory video about Gazebo from [Meta Open Source Team](https://opensource.facebook.com/):
 
 [![Explain Like I’m 5: Gazebo](https://img.youtube.com/vi/pQJkx9HL_04/0.jpg)](https://www.youtube.com/watch?v=OsrBYHIYCYk)
 


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan:

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/12485205/154566395-da555017-2482-4830-b7a7-fb141a6bec6b.png">
