### PR TITLE
Fix UB in test_ref_as_expected

### DIFF
--- a/gazebo/src/cell.rs
+++ b/gazebo/src/cell.rs
@@ -210,6 +210,7 @@ impl<T: ?Sized> AsARef<T> for RefCell<T> {
 mod tests {
     use std::cell::RefCell;
     use std::mem;
+    use std::ptr;
 
     use super::*;
     use crate::cast;
@@ -276,11 +277,11 @@ mod tests {
         let orig = RefCell::new("test".to_owned());
         let p = orig.borrow();
         let p2 = Ref::clone(&p);
-        let (pointer, cell): (usize, usize) = unsafe { mem::transmute(p) };
+        let (pointer, cell): (*const String, *const ()) = unsafe { mem::transmute(p) };
         // We expect the first to be a pointer to the underlying string
-        assert_eq!(pointer, cast::ptr_to_usize(Ref::deref(&p2)));
+        assert_eq!(pointer, ptr::from_ref(Ref::deref(&p2)).cast());
         // We want to make sure the second is never zero
-        assert_ne!(cell, 0);
+        assert!(!cell.is_null());
 
         // Put it back as it was, to make sure our test doesn't leak memory
         let _ignore: Ref<String> = unsafe { mem::transmute((pointer, cell)) };


### PR DESCRIPTION
[Rust has Provenance](https://github.com/rust-lang/rfcs/pull/3559), so this attempt to round-trip a pointer through a `usize` by transmuting it then deallocating through that round-tripped pointer is UB somewhere.

I found this error in a crater run: https://github.com/rust-lang/rust/pull/121282 and here is a fix.